### PR TITLE
Limit Cython to <3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
 requires = ["setuptools",
             "wheel",
-            "cython",
+            "cython<3.0",
             "oldest_supported_numpy"]


### PR DESCRIPTION
Hotfix as current cython version is incompatible.
Fixes #38 