### PR TITLE
Make compatible with Cython 3 (and Python 3.11)

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, macos-latest, ubuntu-latest]
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, macos-latest, ubuntu-latest]
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install --upgrade pip
-        pip install -e .
+        pip install .
     - name: Test with pytest
       run: |        
         pip install -r requirements.txt

--- a/lbfgs/_lowlevel.pyx
+++ b/lbfgs/_lowlevel.pyx
@@ -379,7 +379,7 @@ cdef class LBFGS(object):
             raise TypeError("progress must be callable, got %s" % type(f))
 
         x0 = np.atleast_1d(x0)
-        n = np.product(x0.shape)
+        n = np.prod(x0.shape)
 
         cdef np.npy_intp tshape[1]
         tshape[0] = <np.npy_intp>n

--- a/tests/test_lbfgs.py
+++ b/tests/test_lbfgs.py
@@ -7,8 +7,8 @@ import numpy as np
 
 def test_fmin_lbfgs():
     def f(x, g, *args):
-        g[0] = 2 * x
-        return x ** 2
+        g[:] = 2 * x
+        return x[0] ** 2
 
     xmin = fmin_lbfgs(f, 100., line_search='armijo')
     assert_array_equal(xmin, [0])
@@ -20,8 +20,8 @@ class TestOWLQN:
 
     def test_owl_qn(self):
         def f(x, g, *args):
-            g[0] = 2 * x
-            return x ** 2
+            g[:] = 2 * x
+            return x[0] ** 2
 
         xmin = fmin_lbfgs(f, 100., orthantwise_c=1, line_search='wolfe')
         assert_array_equal(xmin, [0])
@@ -92,7 +92,7 @@ def test_2d():
 def test_class_interface():
     def f(x, g, *args):
         g[:] =  4 * x
-        return x ** 4 + 1
+        return x[0] ** 4 + 1
 
     opt = LBFGS()
     opt.max_iterations = 3

--- a/tests/test_lbfgs.py
+++ b/tests/test_lbfgs.py
@@ -115,3 +115,20 @@ def test_input_validation():
         fmin_lbfgs(lambda x: x, 1e4, "ham")
     with pytest.raises(TypeError):
         fmin_lbfgs(lambda x: x, "spam")
+
+
+def test_exceptions():
+    def f(x, g):
+        assert x < 10.0
+        g[:] = x * 2
+        return x[0] ** 2
+
+    def p(*_):
+        raise Exception("test")
+
+    with pytest.raises(Exception):
+        xmin = fmin_lbfgs(f, 100.0)
+    with pytest.raises(Exception):
+        xmin = fmin_lbfgs(f, 1.0, progress=p)
+    xmin = fmin_lbfgs(f, 9.0)
+    assert_array_equal(xmin, [0])


### PR DESCRIPTION
- Adds the exception information required by `cython` 3 (still compatible with older `cython` versions)
- Adds a `pytest` to check that the exceptions are being handled (Python/C mangles the error type, but the stack trace shows the original error)
- Slightly tweaks some `numpy` syntax to avoid warnings with newer `numpy` versions
- Fixes #38 
- Fixes #40
- Supersedes #39